### PR TITLE
fix: contact email

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Dowload the survey report:
 ## How to Contribute
   - You can contribute to the research by forking the repository and submitting a pull request with changes or improvements.
   - Create interactive versions of the published data.
-  - more information about the research by openning an issue or sending an email to the [research author](survey@mozdevz.org).
+  - More information about the research by openning an issue or sending an email to the <survey@mozdevz.org>.
 
 
 ## License


### PR DESCRIPTION
Dear maintainers, the link for the contact redirects to a file that does not exist, as show on the image below.
![image](https://github.com/mozdevz/Mozambique-Developer-Survey/assets/39647781/fbe9b2f3-295c-486f-a07e-6bf766a31a99)
The changes proposed aim to solve the issue :) 